### PR TITLE
Map based entity tracker

### DIFF
--- a/ktp-api/paper-patches/features/0016-Per-player-glowing.patch
+++ b/ktp-api/paper-patches/features/0016-Per-player-glowing.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Mon, 29 Sep 2025 17:34:24 +0200
+Subject: [PATCH] Per-player glowing
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 639f2af8c96f90a345eb85dbbd27984bb235b51a..9425d8dce679cd3bbd74652f41e457a2988347f8 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -3939,4 +3939,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     @ApiStatus.Experimental
+     PlayerGameConnection getConnection();
++
++    // KTP start - glow override
++    /**
++     * Configures a glow override for the specific entity.
++     *
++     * @param entity       the entity to configure the override for.
++     * @param glowOverride the override, with {@code TRUE} defining the entity to always be glowing, {@code FALSE} defining the entity to never be
++     *                     glowing and {@code NOT_SET} removing any override.
++     */
++    void glowOverride(Entity entity, net.kyori.adventure.util.TriState glowOverride);
++
++    /**
++     * Yields the glow override for the passed entity.
++     *
++     * @param entity the entity instance to check for.
++     *
++     * @return the tri state, {@code NOT_SET} if no override is configured.
++0     */
++    net.kyori.adventure.util.TriState glowOverride(Entity entity);
++    // KTP end - glow override
+ }

--- a/ktp-server/minecraft-patches/features/0006-Map-based-entity-tracker.patch
+++ b/ktp-server/minecraft-patches/features/0006-Map-based-entity-tracker.patch
@@ -1,0 +1,176 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Sat, 27 Sep 2025 15:50:07 +0200
+Subject: [PATCH] Map based entity tracker
+
+Replaces the seenBy reference set with a map, allowing the tracker to
+correctly maintain vanilla state, including all players vanilla would be
+tracking.
+
+The visibility api introduced by bukkit is implemented with a
+pre-computed filtered list of effective trackers on the seen by tracker.
+
+diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
+index eb352aa4296abc3ed4cf31c590bc0be66daf4de3..14c3344ebdd4fd207bbfcd1029616c108600212f 100644
+--- a/net/minecraft/server/level/ChunkMap.java
++++ b/net/minecraft/server/level/ChunkMap.java
+@@ -1139,10 +1139,10 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+ 
+     public class TrackedEntity implements ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerTrackedEntity { // Paper - optimise entity tracker
+         public final ServerEntity serverEntity;
+-        final Entity entity;
++        public final Entity entity; // KTP - map based tracker
+         private final int range;
+         SectionPos lastSectionPos;
+-        public final Set<ServerPlayerConnection> seenBy = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>(); // Paper - Perf: optimise map impl
++        public final io.papermc.paper.network.PaperSeenByTracker seenBy; // Paper - Perf: optimise map impl // KTP - map based tracker
+ 
+         // Paper start - optimise entity tracker
+         private long lastChunkUpdate = -1L;
+@@ -1177,7 +1177,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+ 
+             if (lastChunkUpdate != currChunkUpdate || lastTrackedChunk != chunk) {
+                 // need to purge any players possible not in the chunk list
+-                for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy)) {
++                for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy.theoretical())) { // KTP - map based tracker
+                     final ServerPlayer player = conn.getPlayer();
+                     if (!players.contains(player)) {
+                         this.removePlayer(player);
+@@ -1189,7 +1189,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         @Override
+         public final void moonrise$removeNonTickThreadPlayers() {
+             boolean foundToRemove = false;
+-            for (final ServerPlayerConnection conn : this.seenBy) {
++            for (final ServerPlayerConnection conn : this.seenBy.theoretical()) { // KTP - map based tracker
+                 if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(conn.getPlayer())) {
+                     foundToRemove = true;
+                     break;
+@@ -1200,7 +1200,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+                 return;
+             }
+ 
+-            for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy)) {
++            for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy.theoretical())) { // KTP - map based tracker
+                 ServerPlayer player = conn.getPlayer();
+                 if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(player)) {
+                     this.removePlayer(player);
+@@ -1215,7 +1215,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+             if (this.seenBy.isEmpty()) {
+                 return;
+             }
+-            for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy)) {
++            for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy.theoretical())) { // KTP - map based tracker
+                 ServerPlayer player = conn.getPlayer();
+                 this.removePlayer(player);
+             }
+@@ -1228,6 +1228,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         // Paper end - optimise entity tracker
+ 
+         public TrackedEntity(final Entity entity, final int range, final int updateInterval, final boolean trackDelta) {
++            this.seenBy = new io.papermc.paper.network.PaperSeenByTracker(this); // KTP - map based tracker
+             this.serverEntity = new ServerEntity(ChunkMap.this.level, entity, updateInterval, trackDelta, this::broadcast, this::broadcastIgnorePlayers, this.seenBy); // Paper
+             this.entity = entity;
+             this.range = range;
+@@ -1245,13 +1246,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         }
+ 
+         public void broadcast(Packet<?> packet) {
+-            for (ServerPlayerConnection serverPlayerConnection : this.seenBy) {
++            for (ServerPlayerConnection serverPlayerConnection : this.seenBy.effective()) { // KTP - map based tracker
+                 serverPlayerConnection.send(packet);
+             }
+         }
+ 
+         public void broadcastIgnorePlayers(Packet<?> packet, List<UUID> ignoredPlayers) {
+-            for (ServerPlayerConnection serverPlayerConnection : this.seenBy) {
++            for (ServerPlayerConnection serverPlayerConnection : this.seenBy.effective()) { // KTP - map based tracker
+                 if (!ignoredPlayers.contains(serverPlayerConnection.getPlayer().getUUID())) {
+                     serverPlayerConnection.send(packet);
+                 }
+@@ -1266,16 +1267,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         }
+ 
+         public void broadcastRemoved() {
+-            for (ServerPlayerConnection serverPlayerConnection : this.seenBy) {
++            for (ServerPlayerConnection serverPlayerConnection : this.seenBy.effective()) { // KTP - map based tracker
+                 this.serverEntity.removePairing(serverPlayerConnection.getPlayer());
+             }
+         }
+ 
+         public void removePlayer(ServerPlayer player) {
+             org.spigotmc.AsyncCatcher.catchOp("player tracker clear"); // Spigot
+-            if (this.seenBy.remove(player.connection)) {
+-                this.serverEntity.removePairing(player);
+-            }
++            this.seenBy.remove(player.connection); // KTP - map based tracker
+         }
+ 
+         public void updatePlayer(ServerPlayer player) {
+@@ -1306,21 +1305,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+                     flag = false;
+                 }
+                 // CraftBukkit end
+-                if (flag) {
+-                    if (this.seenBy.add(player.connection)) {
+-                        // Paper start - entity tracking events
+-                        if (io.papermc.paper.event.player.PlayerTrackEntityEvent.getHandlerList().getRegisteredListeners().length == 0 || new io.papermc.paper.event.player.PlayerTrackEntityEvent(player.getBukkitEntity(), this.entity.getBukkitEntity()).callEvent()) {
+-                        this.serverEntity.addPairing(player);
+-                        }
+-                        // Paper end - entity tracking events
+-                        this.serverEntity.onPlayerAdd(); // Paper - fix desync when a player is added to the tracker
+-                    }
+-                } else if (this.seenBy.remove(player.connection)) {
+-                    this.serverEntity.removePairing(player);
+-                }
++                // KTP start - map based tracker - move into own method
++                if (flag) this.seenBy.add(player.connection);
++                else this.seenBy.remove(player.connection);
++                // KTP end - map based tracker - move into own method
+             }
+         }
+ 
++        // KTP start - map based tracker - move into own method
++        public void addPairing(final ServerPlayer serverPlayer) {
++            this.serverEntity.addPairing(serverPlayer);
++            this.serverEntity.onPlayerAdd(); // Paper - fix desync when a player is added to the tracker
++        }
++
++        public void removePairing(final ServerPlayer serverPlayer) {
++            this.serverEntity.removePairing(serverPlayer);
++        }
++        // KTP end - map based tracker - move into own method
++
+         private int scaledRange(int trackingDistance) {
+             return ChunkMap.this.level.getServer().getScaledTrackingDistance(trackingDistance);
+         }
+diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
+index e96d4dee14c05f2fa329bfb1588ec795d4e3d730..b6932e271bde5b4201eb2d169d971f93dc63d5bc 100644
+--- a/net/minecraft/server/level/ServerEntity.java
++++ b/net/minecraft/server/level/ServerEntity.java
+@@ -74,7 +74,7 @@ public class ServerEntity {
+     private boolean wasOnGround;
+     @Nullable
+     private List<SynchedEntityData.DataValue<?>> trackedDataValues;
+-    private final Set<net.minecraft.server.network.ServerPlayerConnection> trackedPlayers; // Paper
++    private final io.papermc.paper.network.PaperSeenByTracker trackedPlayers; // KTP - map based tracker
+ 
+     public ServerEntity(
+         ServerLevel level,
+@@ -84,7 +84,7 @@ public class ServerEntity {
+         Consumer<Packet<?>> broadcast,
+         // Paper start
+         BiConsumer<Packet<?>, List<UUID>> broadcastWithIgnore,
+-        final Set<net.minecraft.server.network.ServerPlayerConnection> trackedPlayers
++        final io.papermc.paper.network.PaperSeenByTracker trackedPlayers // KTP - map based tracker
+         // Paper end
+     ) {
+         this.trackedPlayers = trackedPlayers; // Paper
+@@ -134,7 +134,7 @@ public class ServerEntity {
+                 MapId mapId = itemFrame.cachedMapId; // Paper - Perf: Cache map ids on item frames
+                 MapItemSavedData savedData = MapItem.getSavedData(mapId, this.level);
+                 if (savedData != null) {
+-                    for (final net.minecraft.server.network.ServerPlayerConnection connection : this.trackedPlayers) { // Paper
++                    for (final net.minecraft.server.network.ServerPlayerConnection connection : this.trackedPlayers.effective()) { // Paper // KTP - map based tracker
+                         final ServerPlayer serverPlayer = connection.getPlayer(); // Paper
+                         savedData.tickCarriedBy(serverPlayer, item);
+                         Packet<?> updatePacket = savedData.getUpdatePacket(mapId, serverPlayer);

--- a/ktp-server/minecraft-patches/features/0007-Per-player-glowing.patch
+++ b/ktp-server/minecraft-patches/features/0007-Per-player-glowing.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Sun, 28 Sep 2025 20:15:28 +0200
+Subject: [PATCH] Per-player glowing
+
+
+diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
+index b6932e271bde5b4201eb2d169d971f93dc63d5bc..0be92cc785439bd1e622954e8368cb95957fd389 100644
+--- a/net/minecraft/server/level/ServerEntity.java
++++ b/net/minecraft/server/level/ServerEntity.java
+@@ -409,8 +409,42 @@ public class ServerEntity {
+     private void sendDirtyEntityData() {
+         SynchedEntityData entityData = this.entity.getEntityData();
+         List<SynchedEntityData.DataValue<?>> list = entityData.packDirty();
+-        if (list != null) {
++        sendEntityDataIf: if (list != null) { // KTP - per player glowing
+             this.trackedDataValues = entityData.getNonDefaultValues();
++            // KTP start - per player glowing
++            // Early check that *should* be false for 99% of entities that do not have glow overrides
++            perPlayerGlowingIf: if (this.trackedPlayers.hasAnyGlowOverrides != 0) {
++                int sharedFlagIndex = -1;
++                byte sharedFlagValue = -1;
++                for (int i = 0; i < list.size(); i++) {
++                    final SynchedEntityData.DataValue<?> dataValue = list.get(i);
++                    if (dataValue.id() >= Entity.DATA_SHARED_FLAGS_ID.id()) {
++                        if (dataValue.id() == Entity.DATA_SHARED_FLAGS_ID.id()) {
++                            sharedFlagIndex = i;
++                            sharedFlagValue = (byte) dataValue.value();
++                        }
++                        break;
++                    }
++                }
++                if (sharedFlagIndex == -1) break perPlayerGlowingIf;
++
++                for (final var trackerData : this.trackedPlayers.effectiveData()) {
++                    if (trackerData.glowOverride == net.kyori.adventure.util.TriState.NOT_SET) {
++                        trackerData.connection.send(new ClientboundSetEntityDataPacket(this.entity.getId(), list));
++                        continue;
++                    }
++
++                    final List<SynchedEntityData.DataValue<?>> modifiedCopy = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>(list);
++                    modifiedCopy.set(sharedFlagIndex, SynchedEntityData.DataValue.create(
++                        Entity.DATA_SHARED_FLAGS_ID,
++                        trackerData.patchSharedFlagForGlowOverride(sharedFlagValue)
++                    ));
++                    trackerData.connection.send(new ClientboundSetEntityDataPacket(this.entity.getId(), modifiedCopy));
++                }
++
++                break sendEntityDataIf;
++            }
++            // KTP end - per player glowing
+             this.broadcastAndSend(new ClientboundSetEntityDataPacket(this.entity.getId(), list));
+         }
+ 
+diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
+index d834d20c1c45befe2b5d0520e5c93cf0a512f477..c0c734f5bff6d9edf828ebdeb5fd630a04eddbba 100644
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -291,7 +291,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+     public int invulnerableTime;
+     protected boolean firstTick = true;
+     protected final SynchedEntityData entityData;
+-    protected static final EntityDataAccessor<Byte> DATA_SHARED_FLAGS_ID = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.BYTE);
++    public static final EntityDataAccessor<Byte> DATA_SHARED_FLAGS_ID = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.BYTE); // KTP - public
+     protected static final int FLAG_ONFIRE = 0;
+     private static final int FLAG_SHIFT_KEY_DOWN = 1;
+     private static final int FLAG_SPRINTING = 3;

--- a/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
+++ b/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
@@ -1,0 +1,242 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Sat, 27 Sep 2025 15:48:47 +0200
+Subject: [PATCH] Map based entity tracker
+
+Replaces the seenBy reference set with a map, allowing the tracker to
+correctly maintain vanilla state, including all players vanilla would be
+tracking.
+
+The visibility api introduced by bukkit is implemented with a
+pre-computed filtered list of effective trackers on the seen by tracker.
+
+diff --git a/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d4413a6ac001
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
+@@ -0,0 +1,158 @@
++package io.papermc.paper.network;
++
++import io.papermc.paper.event.player.PlayerTrackEntityEvent;
++import it.unimi.dsi.fastutil.objects.ObjectArrayList;
++import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
++import it.unimi.dsi.fastutil.objects.ReferenceSet;
++import net.minecraft.server.level.ChunkMap;
++import net.minecraft.server.level.ServerPlayer;
++import net.minecraft.server.network.ServerPlayerConnection;
++import org.jspecify.annotations.NullMarked;
++
++/**
++ * The paper seen by tracker aims to expand on vanilla's {@link net.minecraft.server.level.ChunkMap.TrackedEntity#seenBy} set
++ * by instead tracking the entities inside a map.
++ * <p>
++ * While a switch from a set to a map is in itself irrelevant, given most sets are backed by table implementations already, the seen by
++ * tracker also re-implements the bukkit concept of hidden entities.
++ * Previous implementations would keep players that could not see an entity from its seen by tracker, leading to per-tick checks to add
++ * the player in-case the entity was no longer hidden via plugins.
++ * This introduced a rather large hit on the canSee hashmap inside the craftbukkit entity.
++ * <p>
++ * The PaperSeenByTracker proposes a different implementation where entities are tracked after vanilla's rules.
++ * The tracker further maintains an "effective" seen by list which is queried for all sending and tracking purposes into which only those players are added that have not
++ * marked the entity as hidden via the plugin api.
++ * This split into effective and theoretical tracking also enables the attachment of metadata to a players tracking of an entity directly in object, removing the need
++ * for further map lookups in the extremely hot paths.
++ */
++@NullMarked
++public class PaperSeenByTracker {
++
++    private static final int TRACKER_DATA_NON_INITIALISED_INDEX = -2;
++    private static final int TRACKER_DATA_NON_EFFECTIVE = -1;
++
++    // The tracker data holds the additional metadata for the connection.
++    public static class TrackerData {
++        private int effectiveIndex = TRACKER_DATA_NON_INITIALISED_INDEX; // Set to a magic value to quickly check if this entry was just inserted in #add
++    }
++
++    // This implementation is based on the assumption that iteration is a far more common use case than addition and removal
++    // As such, it is worth to maintain a copy of the theoretical table pre-filtered for visible entities.
++    private final Reference2ObjectOpenHashMap<ServerPlayerConnection, TrackerData> theoretical = new Reference2ObjectOpenHashMap<>();
++    private final ObjectArrayList<ServerPlayerConnection> effective = new ObjectArrayList<>();
++
++    private final ChunkMap.TrackedEntity trackedEntity;
++
++    public PaperSeenByTracker(final ChunkMap.TrackedEntity trackedEntity) {
++        this.trackedEntity = trackedEntity;
++    }
++
++    /**
++     * Adds the passed server player to the paper seen by tracker.
++     *
++     * @param connection the server player connection instance to add.
++     */
++    public void add(final ServerPlayerConnection connection) {
++        final TrackerData trackerData = theoretical.computeIfAbsent(connection, ignored -> new TrackerData());
++
++        // tracker data was already tracked in the map, yield false.
++        if (trackerData.effectiveIndex != TRACKER_DATA_NON_INITIALISED_INDEX) return;
++
++        final boolean pluginApiCanSee = connection.getPlayer().getBukkitEntity().canSee(this.trackedEntity.entity.getBukkitEntity());
++        if (!pluginApiCanSee) {
++            trackerData.effectiveIndex = TRACKER_DATA_NON_EFFECTIVE; // Not in the effective set, not visible
++            return;
++        }
++
++        // Added *and* visible, we require tracking logic to run.
++        // Add to iterator list.
++        addToEffectiveAndShow(connection, trackerData);
++    }
++
++    private void addToEffectiveAndShow(final ServerPlayerConnection connection, final TrackerData trackerData) {
++        if (
++            PlayerTrackEntityEvent.getHandlerList().getRegisteredListeners().length != 0
++                && !new PlayerTrackEntityEvent(connection.getPlayer().getBukkitEntity(), this.trackedEntity.entity.getBukkitEntity()).callEvent()
++        ) {
++            return;
++        }
++
++        trackerData.effectiveIndex = effective.size();
++        this.effective.add(connection);
++
++        this.trackedEntity.addPairing(connection.getPlayer());
++    }
++
++    /**
++     * Removes the passed server player to the paper seen by tracker.
++     *
++     * @param connection the server player connection instance to remove.
++     * @return {@code true} if the server player has been remove *and* the player requires removal tracking calls.
++     * The method may return false even if the server player was remove from the tracker incase the player could not see the entity.
++     */
++    public void remove(final ServerPlayerConnection connection) {
++        if (this.theoretical().isEmpty()) return;
++
++        final TrackerData remove = this.theoretical.remove(connection);
++        if (remove == null) return; // Was not in the map in the first place
++        if (remove.effectiveIndex < 0) return; // Was not in the effective list either so, was not visible.
++
++        removeFromEffectiveAndHide(connection, remove);
++    }
++
++    private void removeFromEffectiveAndHide(final ServerPlayerConnection connection, final TrackerData remove) {
++        remove.effectiveIndex = TRACKER_DATA_NON_EFFECTIVE;
++
++        final ServerPlayerConnection relocatedLastElement = this.effective.removeLast();
++        if (relocatedLastElement != connection) {
++            this.effective.set(remove.effectiveIndex, relocatedLastElement);
++
++            // Our only "additional" cost is the one map lookup of the last element.
++            // The cost is acceptable as iteration is a much more common use case than removal.
++            this.theoretical.get(relocatedLastElement).effectiveIndex = remove.effectiveIndex;
++        }
++
++        this.trackedEntity.removePairing(connection.getPlayer());
++    }
++
++    public boolean isTracking(final ServerPlayerConnection connection) {
++        final TrackerData trackerData = this.theoretical.get(connection);
++        return trackerData != null && trackerData.effectiveIndex >= 0;
++    }
++
++    /**
++     * Edits the visibility of a server player on this tracker.
++     *
++     * @param serverPlayer the server player instance.
++     * @param canSeeEntity {@code true} if the player should be able to see the entity, {@code false} if not.
++     * @return the result of the action, defining what the caller is expected to perform for the player.
++     */
++    public void editVisibility(final ServerPlayer serverPlayer, final boolean canSeeEntity) {
++        final TrackerData trackerData = this.theoretical.get(serverPlayer.connection);
++        if (trackerData == null) return;
++        if (trackerData.effectiveIndex >= 0 == canSeeEntity) return;
++
++        if (canSeeEntity) {
++            addToEffectiveAndShow(serverPlayer.connection, trackerData);
++        } else {
++            removeFromEffectiveAndHide(serverPlayer.connection, trackerData);
++        }
++    }
++
++    public ReferenceSet<ServerPlayerConnection> theoretical() {
++        return theoretical.keySet();
++    }
++
++    public ObjectArrayList<ServerPlayerConnection> effective() {
++        return effective;
++    }
++
++    /**
++     * Yields if the tracker has effectively not entities in it.
++     *
++     * @return {@code true} if no effective player is in the tracker.
++     */
++    public boolean isEmpty() {
++        return this.effective.isEmpty();
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index c3e17e1f153eaa34e40cb27d98a999627a590697..4830580676eca80a383df390297f10ab9207bbc4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -745,7 +745,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         ChunkMap.TrackedEntity entityTracker = world.getChunkSource().chunkMap.entityMap.get(this.getEntityId());
+ 
+         if (entityTracker != null) {
+-            for (ServerPlayerConnection connection : entityTracker.seenBy) {
++            for (ServerPlayerConnection connection : entityTracker.seenBy.effective()) { // KTP - map based tracker
+                 players.add(connection.getPlayer().getBukkitEntity());
+             }
+         }
+@@ -762,7 +762,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         ChunkMap.TrackedEntity entityTracker = world.getChunkSource().chunkMap.entityMap.get(this.getEntityId());
+         if (entityTracker == null) return false;
+ 
+-        return entityTracker.seenBy.contains(((CraftPlayer) player).getHandle().connection);
++        return entityTracker.seenBy.isTracking(((CraftPlayer) player).getHandle().connection); // KTP - map based tracker
+     }
+ 
+     @Override
+@@ -1076,7 +1076,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+             return;
+         }
+ 
+-        for (final ServerPlayerConnection connection : entityTracker.seenBy) {
++        for (final ServerPlayerConnection connection : entityTracker.seenBy.effective()) { // KTP - map based tracker
+             this.getHandle().resendPossiblyDesyncedEntityData(connection.getPlayer());
+         }
+     }
+@@ -1222,8 +1222,8 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+             return java.util.Collections.emptySet();
+         }
+ 
+-        Set<org.bukkit.entity.Player> set = new java.util.HashSet<>(tracker.seenBy.size());
+-        for (net.minecraft.server.network.ServerPlayerConnection connection : tracker.seenBy) {
++        Set<org.bukkit.entity.Player> set = new java.util.HashSet<>(tracker.seenBy.effective().size());  // KTP - map based tracker
++        for (net.minecraft.server.network.ServerPlayerConnection connection : tracker.seenBy.effective()) {  // KTP - map based tracker
+             set.add(connection.getPlayer().getBukkitEntity().getPlayer());
+         }
+         return set;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b2e886effaa1bde1b8548ce23651c237678f1369..ec4abb123804776dd879572b7bb5c27cf0e70fd9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2043,7 +2043,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+         ChunkMap tracker = ((ServerLevel) this.getHandle().level()).getChunkSource().chunkMap;
+         ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
+         if (entry != null) {
+-            entry.removePlayer(this.getHandle());
++            entry.seenBy.editVisibility(this.getHandle(), false);  // KTP - map based tracker
+         }
+ 
+         // Remove the hidden entity from this player user list, if they're on it
+@@ -2139,8 +2139,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+         }
+ 
+         ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
+-        if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
+-            entry.updatePlayer(this.getHandle());
++        if (entry != null && !entry.seenBy.isTracking(this.getHandle().connection)) {  // KTP - map based tracker
++            entry.seenBy.editVisibility(getHandle(), true);  // KTP - map based tracker
+         }
+ 
+         this.server.getPluginManager().callEvent(new PlayerShowEntityEvent(this, entity));

--- a/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
+++ b/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
@@ -230,7 +230,7 @@ index c3e17e1f153eaa34e40cb27d98a999627a590697..4830580676eca80a383df390297f10ab
          }
          return set;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b2e886effaa1bde1b8548ce23651c237678f1369..ec4abb123804776dd879572b7bb5c27cf0e70fd9 100644
+index b2e886effaa1bde1b8548ce23651c237678f1369..f0cfc23b6ea89f4aa32551782acbca3f94709681 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2043,7 +2043,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
@@ -238,7 +238,7 @@ index b2e886effaa1bde1b8548ce23651c237678f1369..ec4abb123804776dd879572b7bb5c27c
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
 -            entry.removePlayer(this.getHandle());
-+            entry.seenBy.editVisibility(this.getHandle(), false);  // KTP - map based tracker
++            entry.seenBy.editVisibility(this.getHandle().connection, false);  // KTP - map based tracker
          }
  
          // Remove the hidden entity from this player user list, if they're on it
@@ -249,7 +249,7 @@ index b2e886effaa1bde1b8548ce23651c237678f1369..ec4abb123804776dd879572b7bb5c27c
 -        if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
 -            entry.updatePlayer(this.getHandle());
 +        if (entry != null && !entry.seenBy.isTracking(this.getHandle().connection)) {  // KTP - map based tracker
-+            entry.seenBy.editVisibility(getHandle(), true);  // KTP - map based tracker
++            entry.seenBy.editVisibility(this.getHandle().connection, true);  // KTP - map based tracker
          }
  
          this.server.getPluginManager().callEvent(new PlayerShowEntityEvent(this, entity));

--- a/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
+++ b/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
@@ -12,10 +12,10 @@ pre-computed filtered list of effective trackers on the seen by tracker.
 
 diff --git a/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f712bace0e
+index 0000000000000000000000000000000000000000..1b49b2735fe0dac9b364376533dbca0bf711824d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
-@@ -0,0 +1,169 @@
+@@ -0,0 +1,171 @@
 +package io.papermc.paper.network;
 +
 +import io.papermc.paper.event.player.PlayerTrackEntityEvent;
@@ -23,7 +23,6 @@ index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f7
 +import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 +import it.unimi.dsi.fastutil.objects.ReferenceSet;
 +import net.minecraft.server.level.ChunkMap;
-+import net.minecraft.server.level.ServerPlayer;
 +import net.minecraft.server.network.ServerPlayerConnection;
 +import org.jspecify.annotations.NullMarked;
 +
@@ -38,9 +37,11 @@ index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f7
 + * This introduced a rather large hit on the canSee hashmap inside the craftbukkit entity.
 + * <p>
 + * The PaperSeenByTracker proposes a different implementation where entities are tracked after vanilla's rules.
-+ * The tracker further maintains an "effective" seen by list which is queried for all sending and tracking purposes into which only those players are added that have not
++ * The tracker further maintains an "effective" seen by list which is queried for all sending and tracking purposes into which only those players are
++ * added that have not
 + * marked the entity as hidden via the plugin api.
-+ * This split into effective and theoretical tracking also enables the attachment of metadata to a players tracking of an entity directly in object, removing the need
++ * This split into effective and theoretical tracking also enables the attachment of metadata to a players tracking of an entity directly in object,
++ * removing the need
 + * for further map lookups in the extremely hot paths.
 + */
 +@NullMarked
@@ -51,12 +52,15 @@ index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f7
 +
 +    // The tracker data holds the additional metadata for the connection.
 +    public static class TrackerData {
++
 +        public final ServerPlayerConnection connection;
-+        private int effectiveIndex = TRACKER_DATA_NON_INITIALISED_INDEX; // Set to a magic value to quickly check if this entry was just inserted in #add
++        // Set to a magic value to quickly check if this entry was just inserted in #add
++        private int effectiveIndex = TRACKER_DATA_NON_INITIALISED_INDEX;
 +
 +        public TrackerData(final ServerPlayerConnection connection) {
 +            this.connection = connection;
 +        }
++
 +    }
 +
 +    // This implementation is based on the assumption that iteration is a far more common use case than addition and removal
@@ -81,16 +85,9 @@ index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f7
 +
 +        // tracker data was already tracked in the map, yield false.
 +        if (trackerData.effectiveIndex != TRACKER_DATA_NON_INITIALISED_INDEX) return;
++        trackerData.effectiveIndex = TRACKER_DATA_NON_EFFECTIVE;
 +
-+        final boolean pluginApiCanSee = connection.getPlayer().getBukkitEntity().canSee(this.trackedEntity.entity.getBukkitEntity());
-+        if (!pluginApiCanSee) {
-+            trackerData.effectiveIndex = TRACKER_DATA_NON_EFFECTIVE; // Not in the effective set, not visible
-+            return;
-+        }
-+
-+        // Added *and* visible, we require tracking logic to run.
-+        // Add to iterator list.
-+        addToEffectiveAndShow(connection, trackerData);
++        editVisibility(connection, trackerData, connection.getPlayer().getBukkitEntity().canSee(this.trackedEntity.entity.getBukkitEntity()));
 +    }
 +
 +    private void addToEffectiveAndShow(final ServerPlayerConnection connection, final TrackerData trackerData) {
@@ -112,8 +109,9 @@ index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f7
 +     * Removes the passed server player to the paper seen by tracker.
 +     *
 +     * @param connection the server player connection instance to remove.
++     *
 +     * @return {@code true} if the server player has been remove *and* the player requires removal tracking calls.
-+     * The method may return false even if the server player was remove from the tracker incase the player could not see the entity.
++     *     The method may return false even if the server player was remove from the tracker incase the player could not see the entity.
 +     */
 +    public void remove(final ServerPlayerConnection connection) {
 +        if (this.theoretical().isEmpty()) return;
@@ -148,19 +146,23 @@ index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f7
 +    /**
 +     * Edits the visibility of a server player on this tracker.
 +     *
-+     * @param serverPlayer the server player instance.
++     * @param connection   the server player instance.
 +     * @param canSeeEntity {@code true} if the player should be able to see the entity, {@code false} if not.
-+     * @return the result of the action, defining what the caller is expected to perform for the player.
 +     */
-+    public void editVisibility(final ServerPlayer serverPlayer, final boolean canSeeEntity) {
-+        final TrackerData trackerData = this.theoretical.get(serverPlayer.connection);
++    public void editVisibility(final ServerPlayerConnection connection, final boolean canSeeEntity) {
++        final TrackerData trackerData = this.theoretical.get(connection);
 +        if (trackerData == null) return;
++
++        editVisibility(connection, trackerData, canSeeEntity);
++    }
++
++    public void editVisibility(final ServerPlayerConnection connection, final TrackerData trackerData, final boolean canSeeEntity) {
 +        if (trackerData.effectiveIndex >= 0 == canSeeEntity) return;
 +
 +        if (canSeeEntity) {
-+            addToEffectiveAndShow(serverPlayer.connection, trackerData);
++            addToEffectiveAndShow(connection, trackerData);
 +        } else {
-+            removeFromEffectiveAndHide(serverPlayer.connection, trackerData);
++            removeFromEffectiveAndHide(connection, trackerData);
 +        }
 +    }
 +

--- a/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
+++ b/ktp-server/paper-patches/features/0018-Map-based-entity-tracker.patch
@@ -12,10 +12,10 @@ pre-computed filtered list of effective trackers on the seen by tracker.
 
 diff --git a/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d4413a6ac001
+index 0000000000000000000000000000000000000000..c8c0eda3afa857fd70dbcaa6dbd867f712bace0e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
-@@ -0,0 +1,158 @@
+@@ -0,0 +1,169 @@
 +package io.papermc.paper.network;
 +
 +import io.papermc.paper.event.player.PlayerTrackEntityEvent;
@@ -28,7 +28,7 @@ index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d441
 +import org.jspecify.annotations.NullMarked;
 +
 +/**
-+ * The paper seen by tracker aims to expand on vanilla's {@link net.minecraft.server.level.ChunkMap.TrackedEntity#seenBy} set
++ * The paper seen by tracker aims to expand on vanilla's {@link ChunkMap.TrackedEntity#seenBy} set
 + * by instead tracking the entities inside a map.
 + * <p>
 + * While a switch from a set to a map is in itself irrelevant, given most sets are backed by table implementations already, the seen by
@@ -51,13 +51,19 @@ index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d441
 +
 +    // The tracker data holds the additional metadata for the connection.
 +    public static class TrackerData {
++        public final ServerPlayerConnection connection;
 +        private int effectiveIndex = TRACKER_DATA_NON_INITIALISED_INDEX; // Set to a magic value to quickly check if this entry was just inserted in #add
++
++        public TrackerData(final ServerPlayerConnection connection) {
++            this.connection = connection;
++        }
 +    }
 +
 +    // This implementation is based on the assumption that iteration is a far more common use case than addition and removal
 +    // As such, it is worth to maintain a copy of the theoretical table pre-filtered for visible entities.
 +    private final Reference2ObjectOpenHashMap<ServerPlayerConnection, TrackerData> theoretical = new Reference2ObjectOpenHashMap<>();
 +    private final ObjectArrayList<ServerPlayerConnection> effective = new ObjectArrayList<>();
++    private final ObjectArrayList<TrackerData> effectiveData = new ObjectArrayList<>();
 +
 +    private final ChunkMap.TrackedEntity trackedEntity;
 +
@@ -71,7 +77,7 @@ index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d441
 +     * @param connection the server player connection instance to add.
 +     */
 +    public void add(final ServerPlayerConnection connection) {
-+        final TrackerData trackerData = theoretical.computeIfAbsent(connection, ignored -> new TrackerData());
++        final TrackerData trackerData = theoretical.computeIfAbsent(connection, ignored -> new TrackerData(connection));
 +
 +        // tracker data was already tracked in the map, yield false.
 +        if (trackerData.effectiveIndex != TRACKER_DATA_NON_INITIALISED_INDEX) return;
@@ -97,6 +103,7 @@ index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d441
 +
 +        trackerData.effectiveIndex = effective.size();
 +        this.effective.add(connection);
++        this.effectiveData.add(trackerData);
 +
 +        this.trackedEntity.addPairing(connection.getPlayer());
 +    }
@@ -122,12 +129,12 @@ index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d441
 +        remove.effectiveIndex = TRACKER_DATA_NON_EFFECTIVE;
 +
 +        final ServerPlayerConnection relocatedLastElement = this.effective.removeLast();
++        final TrackerData relocatedLastElementData = this.effectiveData.removeLast();
 +        if (relocatedLastElement != connection) {
 +            this.effective.set(remove.effectiveIndex, relocatedLastElement);
++            this.effectiveData.set(remove.effectiveIndex, relocatedLastElementData);
 +
-+            // Our only "additional" cost is the one map lookup of the last element.
-+            // The cost is acceptable as iteration is a much more common use case than removal.
-+            this.theoretical.get(relocatedLastElement).effectiveIndex = remove.effectiveIndex;
++            relocatedLastElementData.effectiveIndex = remove.effectiveIndex;
 +        }
 +
 +        this.trackedEntity.removePairing(connection.getPlayer());
@@ -163,6 +170,10 @@ index 0000000000000000000000000000000000000000..7e66d1a800d42734211240de79f6d441
 +
 +    public ObjectArrayList<ServerPlayerConnection> effective() {
 +        return effective;
++    }
++
++    public ObjectArrayList<TrackerData> effectiveData() {
++        return effectiveData;
 +    }
 +
 +    /**

--- a/ktp-server/paper-patches/features/0019-Per-player-glowing.patch
+++ b/ktp-server/paper-patches/features/0019-Per-player-glowing.patch
@@ -1,0 +1,140 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <git@lynxplay.dev>
+Date: Sun, 28 Sep 2025 14:59:37 +0200
+Subject: [PATCH] Per-player glowing
+
+
+diff --git a/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
+index 1b49b2735fe0dac9b364376533dbca0bf711824d..c183c5ddf0a6ecfea2fb35d9e3061713189a1189 100644
+--- a/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
++++ b/src/main/java/io/papermc/paper/network/PaperSeenByTracker.java
+@@ -43,6 +43,17 @@ public class PaperSeenByTracker {
+             this.connection = connection;
+         }
+ 
++        // KTP start - glow override
++        public net.kyori.adventure.util.TriState glowOverride = net.kyori.adventure.util.TriState.NOT_SET;
++        public byte patchSharedFlagForGlowOverride(final byte b) {
++            return (byte) switch (glowOverride) {
++                case TRUE -> b | (1 << 6);
++                case FALSE -> b & ~(1 << 6);
++                case NOT_SET -> b;
++            };
++        }
++        // KTP end - glow override
++
+     }
+ 
+     // This implementation is based on the assumption that iteration is a far more common use case than addition and removal
+@@ -70,6 +81,7 @@ public class PaperSeenByTracker {
+         trackerData.effectiveIndex = TRACKER_DATA_NON_EFFECTIVE;
+ 
+         editVisibility(connection, trackerData, connection.getPlayer().getBukkitEntity().canSee(this.trackedEntity.entity.getBukkitEntity()));
++        editGlowOverride(connection, trackerData, connection.getPlayer().getBukkitEntity().glowOverride(this.trackedEntity.entity.getBukkitEntity())); // KTP - per player glow
+     }
+ 
+     private void addToEffectiveAndShow(final ServerPlayerConnection connection, final TrackerData trackerData) {
+@@ -168,4 +180,60 @@ public class PaperSeenByTracker {
+     public boolean isEmpty() {
+         return this.effective.isEmpty();
+     }
++
++    // KTP start - glow override
++    public int hasAnyGlowOverrides = 0;
++
++    /**
++     * Edits the glow override of a server player on this tracker.
++     *
++     * @param connection   the server player instance.
++     * @param glowOverride the override tri state.
++     */
++    public void editGlowOverride(final ServerPlayerConnection connection, final net.kyori.adventure.util.TriState glowOverride) {
++        final TrackerData trackerData = this.theoretical.get(connection);
++        if (trackerData == null) return;
++
++        editGlowOverride(connection, trackerData, glowOverride);
++    }
++
++    public void editGlowOverride(
++        final ServerPlayerConnection connection,
++        final TrackerData trackerData,
++        final net.kyori.adventure.util.TriState glowOverride
++    ) {
++        if (trackerData.glowOverride == glowOverride) return;
++
++        // Two cases where we have to modify the any variable.
++        // Either, we currently are not an override and are editing to be one.
++        // Or we are currently one and are moving to not be one.
++        // THe above check for noop changes allows the following if statements without exhaustive checks for TRUE -> FALSE and FALSE -> TRUE cases.
++        if (trackerData.glowOverride == net.kyori.adventure.util.TriState.NOT_SET) {
++            ++this.hasAnyGlowOverrides;
++        } else if (glowOverride == net.kyori.adventure.util.TriState.NOT_SET) {
++            --this.hasAnyGlowOverrides;
++        }
++
++        // Update cached data
++        trackerData.glowOverride = glowOverride;
++    }
++
++    public void sendUpdatedGlowOverride(
++        final ServerPlayerConnection connection
++    ) {
++        final TrackerData trackerData = this.theoretical.get(connection);
++        if (trackerData == null || trackerData.effectiveIndex < 0) return;
++
++        // Actually send updated faked data to the player
++        final byte value = trackerData.patchSharedFlagForGlowOverride(
++            this.trackedEntity.entity.getEntityData().getItem(net.minecraft.world.entity.Entity.DATA_SHARED_FLAGS_ID).getValue()
++        );
++
++        connection.send(new net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket(
++            this.trackedEntity.entity.getId(),
++            java.util.List.of(net.minecraft.network.syncher.SynchedEntityData.DataValue.create(net.minecraft.world.entity.Entity.DATA_SHARED_FLAGS_ID, value))
++        ));
++    }
++
++    // KTP end - glow override
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index ec4abb123804776dd879572b7bb5c27cf0e70fd9..f805eee99b11ad8c211487386a6fa2e8d401612c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -3543,4 +3543,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+     public PlayerGameConnection getConnection() {
+         return this.getHandle().connection.playerGameConnection;
+     }
++
++    // KTP start - glow override
++    private final it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap<UUID> glowOverrides = new it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap<>();
++    @Override
++    public void glowOverride(
++        final org.bukkit.entity.@org.jspecify.annotations.NonNull Entity entity,
++        final net.kyori.adventure.util.@org.jspecify.annotations.NonNull TriState glowOverride
++    ) {
++        if (glowOverride == TriState.NOT_SET) {
++            glowOverrides.removeBoolean(entity.getUniqueId());
++        } else {
++            glowOverrides.put(entity.getUniqueId(), Boolean.TRUE.equals(glowOverride.toBoolean()));
++        }
++
++        final Entity handleRaw = ((CraftEntity) entity).getHandleRaw();
++        handleRaw.moonrise$getTrackedEntity().seenBy.editGlowOverride(this.getHandle().connection, glowOverride);
++        handleRaw.moonrise$getTrackedEntity().seenBy.sendUpdatedGlowOverride(this.getHandle().connection);
++    }
++
++    /**
++     * Yields the glow override for the passed entity.
++     *
++     * @param entity the entity instance to check for.
++     *
++     * @return the tri state, {@code NOT_SET} if no override is configured.
++     */
++    @Override
++    public net.kyori.adventure.util.TriState glowOverride(final org.bukkit.entity.Entity entity) {
++        return this.glowOverrides.containsKey(entity.getUniqueId())
++                ? net.kyori.adventure.util.TriState.byBoolean(this.glowOverrides.getBoolean(entity.getUniqueId()))
++                : net.kyori.adventure.util.TriState.NOT_SET;
++    }
++    // KTP end - glow override
++
+ }


### PR DESCRIPTION
Replaces the seenBy reference set with a map, allowing the tracker to
correctly maintain vanilla state, including all players vanilla would be
tracking.

The visibility api introduced by bukkit is implemented with a
pre-computed filtered list of effective trackers on the seen by tracker.